### PR TITLE
[*] Add the content_type of response

### DIFF
--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ async def handle(request):
     if name in ALLOWED_FILES:
         try:
             with open(name, 'rb') as index:
-                return web.Response(body=index.read())
+                return web.Response(body=index.read(), content_type='text/html')
         except FileNotFoundError:
             pass
     return web.Response(status=404)


### PR DESCRIPTION
Without this header, the default behavior of my browser is to download the web page as "index.html" to my disk rather than rendering it in the browser when I open `localhost:5000/index.html`. 

My browser is chrome 53.

@kirill-s Please review this commit, thanks!
